### PR TITLE
fix: original msg not updating if no meta found for view params dm cmd

### DIFF
--- a/PromptInspector.py
+++ b/PromptInspector.py
@@ -1214,6 +1214,7 @@ async def formatted_params_dm(ctx: ApplicationContext, message: Message):
 
     if not message.attachments:
         await user_dm.send(f"This message has no attachments. {message.jump_url}")
+        await ctx.edit(content="Sent DM!")
         return
 
     metadata_found = None
@@ -1233,6 +1234,7 @@ async def formatted_params_dm(ctx: ApplicationContext, message: Message):
 
     if not metadata_found:
         await user_dm.send(f"{error_message}\n{message.author.mention} might need to enable metadata embedding in their image generator. {message.jump_url}")
+        await ctx.edit(content="Sent DM!")
         return
 
     # Use the unified function to display in the user's DM


### PR DESCRIPTION
sorry me stupido

Last PR would make the bot get stuck on "is thinking..." if command was used on a message without any attachment with meta

mahiro as apology 
<img width="225" height="225" alt="image" src="https://github.com/user-attachments/assets/faa60756-51d6-42d1-a569-baa971f34742" />
