### PR TITLE
feat: detect MooshieUI via mooshie_version field in sui_image_params

### DIFF
--- a/PromptInspector.py
+++ b/PromptInspector.py
@@ -525,13 +525,18 @@ async def process_and_display_metadata(
                                 pretty_key = key.replace('_', ' ').title()
                                 params_dict[pretty_key] = str(val)
 
-                    elif "sui_image_params" in params_dict: # SwarmUI
-                        img_type = "SwarmUI"
+                    elif "sui_image_params" in params_dict:  # SwarmUI or MooshieUI
                         swarm_params = params_dict.pop('sui_image_params', {})
+                        params_dict.pop('sui_extra_data', None)
+                        params_dict.pop('mooshie_extra', None)
+
+                        is_mooshie = "mooshie_version" in swarm_params
+                        img_type = "MooshieUI" if is_mooshie else "SwarmUI"
+
                         params_dict = {}
                         # Merge swarm params into main dict (convert values to str for safety)
                         for key, val in swarm_params.items():
-                            if "sui_" not in key: 
+                            if "sui_" not in key and key != "mooshie_version":
                                 params_dict[key] = str(val)
 
                     elif "aesthetic_score" in params_dict or 'Guidance Mode' in params_dict: # DrawThings (already parsed to JSON)


### PR DESCRIPTION
Supersedes #9 with a revised detection strategy.

## What changed

MooshieUI now writes a `mooshie_version` field **inside** `sui_image_params` (rather than a separate `mooshie_extra` object). PI-Chan checks for that field to distinguish MooshieUI images from SwarmUI images.

```json
{
  "sui_image_params": {
    "prompt": "...",
    "model": "...",
    "seed": "...",
    "mooshie_version": "0.5.7"
  },
  "sui_extra_data": { ... },
  "mooshie_extra": { ... }
}
```

## Behaviour

| Image source | `mooshie_version` present? | Embed title |
|---|---|---|
| MooshieUI | ✅ | **MooshieUI Parameters** |
| SwarmUI | ❌ | **SwarmUI Parameters** |

- `mooshie_version` is stripped from embed fields (not shown to users)
- `sui_extra_data` and `mooshie_extra` are also stripped
- All other fields (prompt, model, seed, sampler, etc.) pass through unchanged
- SwarmUI images with no `mooshie_version` are completely unaffected

## Testing

Ran a standalone test script against synthetic PNGs with embedded `Comment` metadata — both cases pass:

- MooshieUI image (has `mooshie_version`) → detected as `"MooshieUI"`, no internal fields leaked
- SwarmUI image (no `mooshie_version`) → still detected as `"SwarmUI"`, no regression